### PR TITLE
Appending additional config map out of the foldLeft operation because if the test does not require external services then the additional configs would not be passed to the service.

### DIFF
--- a/src/main/scala/uk/gov/hmrc/play/it/MicroServiceEmbeddedServer.scala
+++ b/src/main/scala/uk/gov/hmrc/play/it/MicroServiceEmbeddedServer.scala
@@ -85,8 +85,8 @@ trait EmbeddedServiceOrchestrator extends ResourceProvider with StartAndStopServ
         (s"Dev.microservice.services.$serviceName.port" -> new Integer(port)) +
         (s"Dev.microservice.services.$serviceName.host" -> "localhost")
 
-      updatedMap ++ additionalConfig
-    })
+      updatedMap
+    }) ++ additionalConfig
 
     val configMapUpdated = onConfigUpdating(configMap)
     val config: Configuration = play.api.Configuration.from(configMapUpdated)


### PR DESCRIPTION
If the service under test does not require other microservices to be started, but it needs some extra configs, currently they will not be passed to the service when started because the configMap is appended inside the foldLeft operation. This PR fixes the problem.
