### PR TITLE
APIS-1502 Add ability to suppress the output of logging

### DIFF
--- a/src/main/scala/uk/gov/hmrc/play/it/ExternalService.scala
+++ b/src/main/scala/uk/gov/hmrc/play/it/ExternalService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/play/it/MicroServiceEmbeddedServer.scala
+++ b/src/main/scala/uk/gov/hmrc/play/it/MicroServiceEmbeddedServer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/play/it/Port.scala
+++ b/src/main/scala/uk/gov/hmrc/play/it/Port.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/play/it/ServiceSpec.scala
+++ b/src/main/scala/uk/gov/hmrc/play/it/ServiceSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/play/it/servicemanager/JsException.scala
+++ b/src/main/scala/uk/gov/hmrc/play/it/servicemanager/JsException.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/play/it/servicemanager/ServiceManagerClient.scala
+++ b/src/main/scala/uk/gov/hmrc/play/it/servicemanager/ServiceManagerClient.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/play/test/DelayProcessing.scala
+++ b/src/main/scala/uk/gov/hmrc/play/test/DelayProcessing.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/play/test/JsonLookups.scala
+++ b/src/main/scala/uk/gov/hmrc/play/test/JsonLookups.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/play/test/LogCapturing.scala
+++ b/src/main/scala/uk/gov/hmrc/play/test/LogCapturing.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/play/test/LogSuppressing.scala
+++ b/src/main/scala/uk/gov/hmrc/play/test/LogSuppressing.scala
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.play.test
+
+import ch.qos.logback.classic.{Level, Logger}
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.filter.Filter
+import ch.qos.logback.core.spi.FilterReply
+import play.api.LoggerLike
+
+import scala.collection.mutable
+import scala.collection.JavaConversions._
+
+class SuppressedLogFilter(val messagesContaining: String) extends Filter[ILoggingEvent] {
+  private val suppressedEntries = new mutable.MutableList[ILoggingEvent]()
+
+  override def decide(event: ILoggingEvent): FilterReply = {
+    if (event.getMessage.contains(messagesContaining)) {
+      suppressedEntries += event
+      FilterReply.DENY
+    } else {
+      FilterReply.NEUTRAL
+    }
+  }
+
+  def hasError(msg: String) = {
+    suppressedEntries.exists(entry => entry.getLevel == Level.ERROR && entry.getMessage.contains(msg))
+  }
+
+  def hasWarn(msg: String) = {
+    suppressedEntries.exists(entry => entry.getLevel == Level.WARN && entry.getMessage.contains(msg))
+  }
+
+  def hasInfo(msg: String) = {
+    suppressedEntries.exists(entry => entry.getLevel == Level.INFO && entry.getMessage.contains(msg))
+  }
+}
+
+trait LogSuppressing {
+  def withSuppressedLoggingFrom(logger: Logger, messagesContaining: String)(body: (=> SuppressedLogFilter) => Unit) {
+
+    val appenders = logger.iteratorForAppenders().toList
+    val appendersWithFilters = appenders.map(appender => appender->appender.getCopyOfAttachedFiltersList)
+
+    val filter = new SuppressedLogFilter(messagesContaining)
+    appenders.foreach(_.addFilter(filter))
+
+    try body(filter)
+    finally {
+      appendersWithFilters.foreach { case(appender, filters) =>
+        appender.clearAllFilters
+        filters.foreach(appender.addFilter(_))
+      }
+    }
+  }
+
+  def withSuppressedLoggingFrom(logger: LoggerLike, messagesContaining: String)(body: (=> SuppressedLogFilter) => Unit) {
+    withSuppressedLoggingFrom(logger.logger.asInstanceOf[Logger], messagesContaining)(body)
+  }
+}
+
+

--- a/src/main/scala/uk/gov/hmrc/play/test/UnitSpec.scala
+++ b/src/main/scala/uk/gov/hmrc/play/test/UnitSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/play/test/WithFakeApplication.scala
+++ b/src/main/scala/uk/gov/hmrc/play/test/WithFakeApplication.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
This is a new trait to mix in to unit tests to allow the output of log entries containing the given string in their message to be suppressed and captured. This is in particular to allow tests that deliberately cause an error to be logged to suppress the actual output of the log entry and stack trace to the console, which creates a lot of noise in the build log making it harder to spot genuine errors. The suppressed log entries are captured so that the test can assert that the entry did get logged (useful to test where logging forms part of the requirements).

A partial example of how it will be used is:
```
    "return 500 on error in password checking" in new Setup {
      withSuppressedLoggingFrom(Logger, "expected test error") { suppressedLogs =>
        val expected = new RuntimeException("expected test error")
        mockAuthenticationWith(Future.failed(expected))

        val result = await(underTest.checkPassword(passwordCheckRequest))

        status(result) shouldBe 500
        jsonBodyOf(result) shouldBe error(INTERNAL_SERVER_ERROR, expected.getMessage)
        suppressedLogs.hasError("expected test error") shouldBe true
      }
    }
```
