### PR TITLE
PLATOPS-1058 Support for custom Play application loaders in services instantiated in integration tests

### DIFF
--- a/src/main/scala/uk/gov/hmrc/play/it/ExternalService.scala
+++ b/src/main/scala/uk/gov/hmrc/play/it/ExternalService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/play/it/Port.scala
+++ b/src/main/scala/uk/gov/hmrc/play/it/Port.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/play/it/ServiceSpec.scala
+++ b/src/main/scala/uk/gov/hmrc/play/it/ServiceSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/play/it/servicemanager/JsException.scala
+++ b/src/main/scala/uk/gov/hmrc/play/it/servicemanager/JsException.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/play/it/servicemanager/ServiceManagerClient.scala
+++ b/src/main/scala/uk/gov/hmrc/play/it/servicemanager/ServiceManagerClient.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/play/test/DelayProcessing.scala
+++ b/src/main/scala/uk/gov/hmrc/play/test/DelayProcessing.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/play/test/JsonLookups.scala
+++ b/src/main/scala/uk/gov/hmrc/play/test/JsonLookups.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/play/test/LogCapturing.scala
+++ b/src/main/scala/uk/gov/hmrc/play/test/LogCapturing.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/play/test/UnitSpec.scala
+++ b/src/main/scala/uk/gov/hmrc/play/test/UnitSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/play/test/WithFakeApplication.scala
+++ b/src/main/scala/uk/gov/hmrc/play/test/WithFakeApplication.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
When we instantiate the service in integration tests we would like to take in account 'play.application.loader' property if specified in application.conf

Refactored common libraries (bootstrap-play-25, auditing, monitoring) use such a customized loader to setup itself, and configure DI modules. We need to be able to test this behaviour in our integration tests as well.

The main idea of the change is that, instead of directly creating GuiceApplicationBuilder with hardcoded settings,
we instantiate proper application loader (using 'play.application.loader' property and falling back to default one if property missing), then we use the loader to create and configure GuiceApplicationBuilder.

This change is expected to be backwards compatible.