### PR TITLE
Proposed changes to conform to new build pipeline

### DIFF
--- a/src/main/scala/uk/gov/hmrc/play/it/MicroServiceEmbeddedServer.scala
+++ b/src/main/scala/uk/gov/hmrc/play/it/MicroServiceEmbeddedServer.scala
@@ -89,8 +89,8 @@ trait EmbeddedServiceOrchestrator extends ResourceProvider with StartAndStopServ
       Logger.debug(s"External service '$serviceName' is running on port: $port")
 
       val updatedMap = map +
-        (s"$applicationMode.microservice.services.$serviceName.port" -> new Integer(port)) +
-        (s"$applicationMode.microservice.services.$serviceName.host" -> "localhost")
+        (s"microservice.services.$serviceName.port" -> new Integer(port)) +
+        (s"microservice.services.$serviceName.host" -> "localhost")
 
       updatedMap
     }) ++ additionalConfig
@@ -141,7 +141,7 @@ trait MongoTestConfiguration extends AdditionalConfigProvider {
   val dbName: String = testId.toString
 
   abstract override protected def additionalConfig =
-    super.additionalConfig + (s"$applicationMode.microservice.mongodb.uri" -> s"mongodb://localhost:27017/$dbName")
+    super.additionalConfig + ("microservice.mongodb.uri" -> s"mongodb://localhost:27017/$dbName")
 }
 
 object UrlHelper {


### PR DESCRIPTION
Hi,

As part of the build pipeline work environment configuration has been removed from being declared with the configuration itself e.g. dev.config.key or prod.config.key. This library still contains referencing to environment dependant config which I believed was to be removed as part of the build pipeline upgrade.

I have proposed changes in this PR but they have not been tested, merely a suggestion to look into.


Kind Regards,

Joe